### PR TITLE
fix: add quote for path

### DIFF
--- a/src/Translumo/Translumo.csproj
+++ b/src/Translumo/Translumo.csproj
@@ -139,7 +139,7 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition=" '$(SkipBinariesExtract)' == '' ">
-    <Exec Command="$(SolutionDir)\binaries_extract.bat $(TargetDir)" />
+    <Exec Command="&quot;$(SolutionDir)binaries_extract.bat&quot; &quot;$(TargetDir)&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Some path will have space in between, add quote for it to build on systems where path have space