### PR TITLE
Add Ollama llama3:latest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 </p>
 <p align="center"><b>EN</b> | <a href="docs/README-RU.md"><b>RU</b></a></p>
 <p align="center">Advanced screen translator. <b>Translumo</b> is able to detect and translate appearing in the selected area text in real-time (e.g. subtitles).</p>
+
+<h1>My Edition</h1>
+modify Translator.cs, TranslatorFactory.cs, to add a llama enum type; 
+Add LlamaTranslator.cs, LlamaContainer.cs
+
 <h1>Main features</h1>
 <ul>
   <li><b>High text recognition precision</b></li>

--- a/src/Translumo.Translation/Llama/LlamaContainer.cs
+++ b/src/Translumo.Translation/Llama/LlamaContainer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text;
+using System.Threading.Tasks;
+using Translumo.Translation.Configuration;
+using Translumo.Utils.Http;
+
+namespace Translumo.Translation.Llama
+{
+    public sealed class LlamaContainer : TranslationContainer
+    {
+        public LlamaContainer(Proxy proxy = null, bool isPrimary = false) : base(proxy, isPrimary)
+        {
+        }
+    }
+}

--- a/src/Translumo.Translation/Llama/LlamaTranslator.cs
+++ b/src/Translumo.Translation/Llama/LlamaTranslator.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Transactions;
+using System.Web;
+using Microsoft.Extensions.Logging;
+using Translumo.Infrastructure.Constants;
+using Translumo.Infrastructure.Language;
+using Translumo.Translation.Configuration;
+using Translumo.Translation.Exceptions;
+using Translumo.Utils.Http;
+
+namespace Translumo.Translation.Llama
+{
+    public class LlamaTranslator : BaseTranslator<LlamaContainer>
+    {
+        private const string LLAMA_API_URL = "http://localhost:11434/api/generate";
+        private readonly HttpClient _httpClient;
+
+        public LlamaTranslator(TranslationConfiguration translationConfiguration, LanguageService languageService, ILogger logger)
+            : base(translationConfiguration, languageService, logger)
+        {
+            _httpClient = new HttpClient();
+        }
+
+        public override Task<string> TranslateTextAsync(string sourceText)
+        {
+            //TODO: Temp implementation for specific lang
+            if (TargetLangDescriptor.Language == Languages.PortugueseBrazil)
+            {
+                throw new TransactionException("Llama translate is unavailable for this language");
+            }
+
+            return base.TranslateTextAsync(sourceText);
+        }
+
+
+
+        protected override async Task<string> TranslateTextInternal(LlamaContainer container, string sourceText)
+        {
+            var requestBody = new
+            {
+                model = "llama3:latest", // 你可以改成本地安装的模型，如 "llama2"、"mistral"
+                prompt = $"Translate this text to {TargetLangDescriptor.Language.ToString()}: {sourceText}",
+                stream = false // 设置 stream=false 以同步返回完整翻译结果
+            };
+
+            // 序列化 JSON
+            var content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+
+            // 发送 HTTP 请求到本地 Llama 服务器
+            HttpResponseMessage response = await _httpClient.PostAsync(LLAMA_API_URL, content);
+
+            if (response.IsSuccessStatusCode)
+            {
+                string responseBody = await response.Content.ReadAsStringAsync();
+
+                // 解析 JSON 响应
+                using JsonDocument jsonDoc = JsonDocument.Parse(responseBody);
+                string translatedText = jsonDoc.RootElement.GetProperty("response").GetString();
+
+                return translatedText;
+            }
+
+            throw new TranslationException($"Llama translation failed. Status Code: {response.StatusCode}");
+        }
+
+        protected override IList<LlamaContainer> CreateContainers(TranslationConfiguration configuration)
+        {
+            var result = configuration.ProxySettings.Select(proxy => new LlamaContainer(proxy)).ToList();
+            result.Add(new LlamaContainer(isPrimary: true));
+
+            return result;
+        }
+    }
+}

--- a/src/Translumo.Translation/TranslatorFactory.cs
+++ b/src/Translumo.Translation/TranslatorFactory.cs
@@ -5,6 +5,7 @@ using Translumo.Infrastructure.Language;
 using Translumo.Translation.Configuration;
 using Translumo.Translation.Deepl;
 using Translumo.Translation.Google;
+using Translumo.Translation.Llama;
 using Translumo.Translation.Papago;
 using Translumo.Translation.Yandex;
 
@@ -35,6 +36,8 @@ namespace Translumo.Translation
                     return new PapagoTranslator(translatorConfiguration, _languageService, _logger);
                 case Translators.Google:
                     return new GoogleTranslator(translatorConfiguration, _languageService, _logger);
+                case Translators.Llama3_Latest:
+                    return new LlamaTranslator(translatorConfiguration, _languageService, _logger);
                 default:
                     throw new NotSupportedException();
             }

--- a/src/Translumo.Translation/Translators.cs
+++ b/src/Translumo.Translation/Translators.cs
@@ -9,6 +9,8 @@ namespace Translumo.Translation
 
         Google = 2,
 
-        Papago = 3
+        Papago = 3,
+
+        Llama3_Latest = 4
     }
 }


### PR DESCRIPTION
Add Ollama llama3:latest support, users must install ollama on their PC and add folder path (which contains ollama.exe) to PATH, then run "ollama run llama3:latest" to install llama3 model.