### PR TITLE
Add voice selection for Windows TTS engine

### DIFF
--- a/src/Translumo.TTS/Engines/WindowsTTSEngine.cs
+++ b/src/Translumo.TTS/Engines/WindowsTTSEngine.cs
@@ -8,13 +8,23 @@ public class WindowsTTSEngine : ITTSEngine
     private readonly VoiceInfo _voiceInfo;
     private readonly SpeechSynthesizer _synthesizer;
 
-    public WindowsTTSEngine(string languageCode)
+    public WindowsTTSEngine(string languageCode, string voiceName = null)
     {
         _synthesizer = new SpeechSynthesizer();
         _synthesizer.SetOutputToDefaultAudioDevice();
         _synthesizer.Rate = 3;
 
-        _voiceInfo = _synthesizer.GetInstalledVoices(new CultureInfo(languageCode)).FirstOrDefault()?.VoiceInfo;
+        // Get all available voices
+        var availableVoices = _synthesizer.GetInstalledVoices(new CultureInfo(languageCode));
+        
+        if (!string.IsNullOrEmpty(voiceName))
+        {
+            _voiceInfo = availableVoices
+                .FirstOrDefault(v => v.VoiceInfo.Name.Equals(voiceName, StringComparison.OrdinalIgnoreCase))
+                ?.VoiceInfo;
+        }
+        
+        _voiceInfo ??= availableVoices.FirstOrDefault()?.VoiceInfo;
     }
 
     public void SpeechText(string text)

--- a/src/Translumo.TTS/TtsConfiguration.cs
+++ b/src/Translumo.TTS/TtsConfiguration.cs
@@ -12,12 +12,14 @@ public class TtsConfiguration : BindableBase
         {
             TtsLanguage = Languages.English,
             TtsSystem = TTSEngines.None,
-            InstalledWinTtsLanguages = new List<Languages>()
+            InstalledWinTtsLanguages = new List<Languages>(),
+            SelectedVoiceName = string.Empty
         };
 
     private TTSEngines _ttsSystem;
     private Languages _ttsLanguage;
     private List<Languages> _installedWinTtsLanguages;
+    private string _selectedVoiceName;
 
     public TTSEngines TtsSystem
     {
@@ -43,6 +45,15 @@ public class TtsConfiguration : BindableBase
         set
         {
             SetProperty(ref _installedWinTtsLanguages, value);
+        }
+    }
+    
+    public string SelectedVoiceName
+    {
+        get => _selectedVoiceName;
+        set
+        {
+            SetProperty(ref _selectedVoiceName, value);
         }
     }
 }

--- a/src/Translumo.TTS/TtsFactory.cs
+++ b/src/Translumo.TTS/TtsFactory.cs
@@ -22,7 +22,9 @@ namespace Translumo.TTS
             ttsConfiguration.TtsSystem switch
             {
                 TTSEngines.None => new NoneTTSEngine(),
-                TTSEngines.WindowsTTS => new WindowsTTSEngine(GetLangCode(ttsConfiguration)),
+                TTSEngines.WindowsTTS => new WindowsTTSEngine(
+                    GetLangCode(ttsConfiguration), 
+                    ttsConfiguration.SelectedVoiceName),
                 //TTSEngines.SileroTTS => new SileroTTSEngine(_pythonEngine, GetLangCode(ttsConfiguration)),
                 _ => throw new NotSupportedException()
             };

--- a/src/Translumo.TTS/WindowsTTSHelper.cs
+++ b/src/Translumo.TTS/WindowsTTSHelper.cs
@@ -95,6 +95,42 @@ namespace Translumo.TTS
             };
 
             return process;  // Return the process after completion
-        }       
+        } 
+
+        public static List<VoiceInfo> GetAvailableVoicesForLanguage(string languageTag)
+        {
+            using var synth = new SpeechSynthesizer();
+            var result = new List<VoiceInfo>();
+            
+            try
+            {
+                var voices = synth.GetInstalledVoices(new CultureInfo(languageTag));
+                if (voices.Count > 0)
+                {
+                    result.AddRange(voices.Select(v => v.VoiceInfo));
+                    return result;
+                }
+            }
+            catch
+            {
+                
+            }
+
+            try
+            {
+                var shortTag = languageTag.Split('-')[0];
+                var voices = synth.GetInstalledVoices(new CultureInfo(shortTag));
+                if (voices.Count > 0)
+                {
+                    result.AddRange(voices.Select(v => v.VoiceInfo));
+                }
+            }
+            catch
+            {
+
+            }
+
+            return result;
+        }      
     }
 }

--- a/src/Translumo/MVVM/Views/LanguagesSettingsView.xaml
+++ b/src/Translumo/MVVM/Views/LanguagesSettingsView.xaml
@@ -97,6 +97,20 @@
                     Content="{DynamicResource Str.LangSettings.TtsSystem}"
                     Style="{StaticResource ControlCaptionLabel}" />
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Visibility="{Binding IsTtsWindowsSelected, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ComboBox 
+                    ItemsSource="{Binding AvailableVoices}"
+                    SelectedItem="{Binding SelectedVoice, Mode=TwoWay}"
+                    DisplayMemberPath="Name"
+                    Width="130"
+                    FontSize="14"
+                    Style="{DynamicResource MaterialDesignComboBox}"/>
+                <Label
+                    Margin="10,0,0,0"
+                    HorizontalAlignment="Stretch"
+                    Content="Voices"
+                    Style="{StaticResource ControlCaptionLabel}" />
+            </StackPanel>
             <GroupBox Margin="0,20,0,0" Style="{StaticResource MaterialDesignGroupBox}">
                 <GroupBox.Header>
                     <Label


### PR DESCRIPTION
Introduces support for selecting specific voices in the Windows TTS engine. Updates configuration, view model, and UI to allow users to choose from available voices for the selected language, and ensures the selected voice is used for speech synthesis.